### PR TITLE
helpers.rb: Fix typo in :contributor keyword

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -83,7 +83,7 @@ helpers do
       orcid = query_info[:value][0]
       names = Array(query_info[:value][1..-1]).uniq
       orcid_terms(orcid, names)
-    when :contributpr
+    when :contributor
       "creator:#{query_info[:value]} OR contributor:#{query_info[:value]}"
     when :year
       "publicationYear:\"#{query_info[:value]}\""


### PR DESCRIPTION
Typo in query_terms stops creator|contributor|author field name look up