### PR TITLE
use new mathjax cdn

### DIFF
--- a/views/layout.haml
+++ b/views/layout.haml
@@ -42,7 +42,7 @@
             inlineMath: [["$","$"],["\\(","\\)"]]
           }
         });
-    %script{:type => 'text/javascript', :src => '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML'}
+    %script{:type => 'text/javascript', :src => 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML'}
     %script{:type => 'text/javascript', :src => 'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.12/clipboard.min.js'}
     %script{:type => 'text/javascript', :src => '/javascripts/itemlist.js'}
     %script{:type => 'text/javascript', :src => '/javascripts/schemaorg.js'}


### PR DESCRIPTION
See https://www.mathjax.org/cdn-shutting-down/ for more info.